### PR TITLE
Fix FBXLoader import

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,7 +2,9 @@
 
 
 import * as THREE from 'three';
-import { FBXLoader } from './FBXLoader.js'; // Assuming FBXLoader.js is in the js/ folder and is an ES module
+// Use the FBXLoader provided by the Three.js examples via the import map
+// This avoids missing local dependency errors when running the simulation
+import { FBXLoader } from 'three/addons/loaders/FBXLoader.js';
 
 
 // --- SCENE SETUP ---


### PR DESCRIPTION
## Summary
- switch `FBXLoader` import to the version provided by the Three.js examples

## Testing
- `node js/main.js` *(fails: Cannot find package 'three')*

------
https://chatgpt.com/codex/tasks/task_e_684bb6e9deec8325b0b9fc7ac24cf91c